### PR TITLE
fix FD_ZERO build on clang 13

### DIFF
--- a/x86_64-linux-gnu/bits/select.h
+++ b/x86_64-linux-gnu/bits/select.h
@@ -32,9 +32,9 @@
 
 # define __FD_ZERO(fdsp) \
   do {									      \
-    int __d0, __d1;							      \
+    int _d0, _d1;							      \
     __asm__ __volatile__ ("cld; rep; " __FD_ZERO_STOS			      \
-			  : "=c" (__d0), "=D" (__d1)			      \
+			  : "=c" (_d0), "=D" (_d1)			      \
 			  : "a" (0), "0" (sizeof (fd_set)		      \
 					  / sizeof (__fd_mask)),	      \
 			    "1" (&__FDS_BITS (fdsp)[0])			      \


### PR DESCRIPTION
```
2021-10-11 07:36:02 /ClickHouse/src/Storages/FileLog/DirectoryWatcherBase.cpp:65:9: error: identifier '__d0' is reserved because it starts with '__' [-Werror,-Wreserved-identifier]
2021-10-11 07:36:02         FD_ZERO(&fds);
2021-10-11 07:36:02         ^
2021-10-11 07:36:02 /ClickHouse/contrib/libc-headers/x86_64-linux-gnu/sys/select.h:88:26: note: expanded from macro 'FD_ZERO'
2021-10-11 07:36:02 #define FD_ZERO(fdsetp)         __FD_ZERO (fdsetp)
2021-10-11 07:36:02                                 ^
2021-10-11 07:36:02 /ClickHouse/contrib/libc-headers/x86_64-linux-gnu/bits/select.h:35:9: note: expanded from macro '__FD_ZERO'
2021-10-11 07:36:02     int __d0, __d1;                                                           \
2021-10-11 07:36:02         ^
2021-10-11 07:36:02 /ClickHouse/src/Storages/FileLog/DirectoryWatcherBase.cpp:65:9: error: identifier '__d1' is reserved because it starts with '__' [-Werror,-Wreserved-identifier]
2021-10-11 07:36:02 /ClickHouse/contrib/libc-headers/x86_64-linux-gnu/sys/select.h:88:26: note: expanded from macro 'FD_ZERO'
2021-10-11 07:36:02 #define FD_ZERO(fdsetp)         __FD_ZERO (fdsetp)
2021-10-11 07:36:02                                 ^
2021-10-11 07:36:02 /ClickHouse/contrib/libc-headers/x86_64-linux-gnu/bits/select.h:35:15: note: expanded from macro '__FD_ZERO'
2021-10-11 07:36:02     int __d0, __d1;                                                           \
2021-10-11 07:36:02               ^
2021-10-11 07:36:02 2 errors generated.
```
Build error with `clang 13` in https://github.com/ClickHouse/ClickHouse/pull/25969, https://clickhouse-test-reports.s3.yandex.net/25969/a57e97d2e0ae13e68c8072a7d51c2a02cdf3aea3/fast_test/runlog.out.log

cc @alexey-milovidov 